### PR TITLE
fix(template): improve frontmatter regex to support CRLF line endings

### DIFF
--- a/src/worker/services/library-template.ts
+++ b/src/worker/services/library-template.ts
@@ -611,7 +611,7 @@ export class LibraryTemplateService {
             const template = templateContent || DEFAULT_ITEM_TEMPLATE;
 
             // Separate Frontmatter and Body
-            const frontmatterRegex = /^---\s*([\s\S]*?)\s*---\n/;
+            const frontmatterRegex = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
             const match = template.match(frontmatterRegex);
 
             let templateFrontmatterRaw = "";

--- a/src/worker/services/local-template.ts
+++ b/src/worker/services/local-template.ts
@@ -135,7 +135,7 @@ export class LocalTemplateService {
             const template = templateContent || DEFAULT_LOCAL_NOTE_TEMPLATE;
 
             // Separate Frontmatter and Body
-            const frontmatterRegex = /^---\s*([\s\S]*?)\s*---\n/;
+            const frontmatterRegex = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
             const match = template.match(frontmatterRegex);
 
             let templateFrontmatterRaw = "";

--- a/tests/integration/library-template.test.ts
+++ b/tests/integration/library-template.test.ts
@@ -284,6 +284,20 @@ describe("frontmatter", () => {
         expect(out).toContain("title: A Study of Things");
     });
 
+    test("a CRLF template's frontmatter is still detected", async () => {
+        const item = await seedArticle();
+        const out = await service.renderLibrarySourceNote(
+            item,
+            "---\r\nstatus: {{ item.itemType }}\r\n---\r\nbody",
+            {},
+        );
+        expect(out).toContain("status: journalArticle");
+        expect(out).toContain("body");
+        // The template's CRLF delimiters must be consumed by the frontmatter
+        // split, not leak into the body (which would mean detection failed).
+        expect(out).not.toContain("---\r\n");
+    });
+
     test("unparseable frontmatter is logged and skipped, not fatal", async () => {
         const item = await seedArticle();
         host.parseYaml = () => Promise.reject(new Error("bad yaml"));

--- a/tests/integration/local-note.test.ts
+++ b/tests/integration/local-note.test.ts
@@ -149,6 +149,21 @@ describe("local template rendering", () => {
         expect(out).not.toContain("hand-written");
     });
 
+    test("a CRLF template's frontmatter is still detected", async () => {
+        const out = await templates.renderLocalNote(
+            pdf(),
+            [],
+            "---\r\nstatus: fresh\r\n---\r\nbody",
+            { status: "hand-written" },
+        );
+
+        expect(out).toContain("status: fresh");
+        expect(out).not.toContain("hand-written");
+        // The template's CRLF delimiters must be consumed by the frontmatter
+        // split, not leak into the body (which would mean detection failed).
+        expect(out).not.toContain("---\r\n");
+    });
+
     test("keys the template does not mention are carried over", async () => {
         const out = await templates.renderLocalNote(pdf(), [], "body", {
             "my-own-field": "kept",


### PR DESCRIPTION
Update the frontmatter regular expression in both LibraryTemplateService and LocalTemplateService to correctly handle carriage return and line feed characters. This ensures that templates with Windows-style line endings are parsed correctly.

Old pattern required LF after both --- delimiters; CRLF templates fell through to the body, so frontmatter keys were never merged and the raw ---\r\n leaked into the note. New pattern is the codebase's canonical CRLF-aware form, already used in persist-regions.ts, zotflow-lock-extension.ts, zotflow-editable-region-extension.ts, and zotflow-region-decoration-extension.ts. It also fixes a latent edge: the old \s* before the closing --- could swallow the first body line's leading whitespace.