### PR TITLE
feat: support multiple Zotero storage directories and native PDF viewer

### DIFF
--- a/src/settings/sections/source-notes-section.ts
+++ b/src/settings/sections/source-notes-section.ts
@@ -145,13 +145,13 @@ export class SourceNotesSection {
                         },
                     },
                     {
-                        name: "Zotero Storage Path",
-                        desc: "Absolute path to Zotero's storage directory (e.g. C:\\Users\\name\\Zotero\\storage). Enter the complete path without using a home-directory shortcut such as ~.",
+                        name: "Zotero Storage Paths",
+                        desc: "One or more absolute paths to Zotero storage directories, separated by semicolons. ZotFlow checks them in order (e.g. C:\\Users\\name\\Zotero\\storage; D:\\Archive\\Zotero\\storage). Do not use a home-directory shortcut such as ~.",
                         control: {
                             type: "text",
                             key: "zoteroStoragePath",
                             placeholder:
-                                "e.g. C:\\Users\\name\\Zotero\\storage",
+                                "e.g. C:\\Users\\name\\Zotero\\storage; D:\\Archive\\Zotero\\storage",
                         },
                     },
                 ],

--- a/src/ui/tree-view/Node.tsx
+++ b/src/ui/tree-view/Node.tsx
@@ -11,6 +11,7 @@ import { workerBridge } from "bridge";
 
 import {
     openAttachment,
+    openAttachmentInNativePdfViewer,
     openItemNote,
     openItemNoteInEditor,
     openItemNoteInSourceNote,
@@ -484,6 +485,35 @@ export const NodeItem = ({ node, style }: NodeRendererProps<ViewNode>) => {
         }
 
         if (nodeType === "item") {
+            if (
+                node.data.itemType === "attachment" &&
+                (node.data.contentType === "application/pdf" ||
+                    node.data.name.toLowerCase().endsWith(".pdf"))
+            ) {
+                menu.addItem((item) => {
+                    item.setTitle("Open in Obsidian native PDF viewer")
+                        .setIcon("file-text")
+                        .onClick(async () => {
+                            try {
+                                await openAttachmentInNativePdfViewer(
+                                    node.data.libraryID,
+                                    node.data.key,
+                                    services.app,
+                                );
+                            } catch (err) {
+                                services.logService.error(
+                                    "Failed to open attachment in native PDF viewer",
+                                    "TreeView",
+                                    err,
+                                );
+                                services.notificationService.notify(
+                                    "error",
+                                    "Failed to open attachment in Obsidian's native PDF viewer.",
+                                );
+                            }
+                        });
+                });
+            }
             menu.addItem((item) => {
                 item.setTitle("Open in Zotero")
                     .setIcon("external-link")

--- a/src/utils/viewer.ts
+++ b/src/utils/viewer.ts
@@ -1,10 +1,13 @@
-import { App, MarkdownView, TFile } from "obsidian";
+import { App, MarkdownView, Notice, TFile, normalizePath } from "obsidian";
 import { ZOTERO_READER_VIEW_TYPE, ZoteroReaderView } from "../ui/reader/view";
 import { NOTE_EDITOR_VIEW_TYPE, NoteEditorView } from "../ui/note-editor/view";
 import { workerBridge } from "../bridge";
 import { services } from "../services/services";
+import { saveBinaryFile } from "utils/file";
 
 import type { ReaderNavigation } from "types/zotero-reader";
+import type { AttachmentData } from "types/zotero-item";
+import type { IDBZoteroItem } from "types/db-schema";
 
 /**
  * Open an attachment in the default application.
@@ -60,6 +63,61 @@ export async function openAttachment(
             JSON.parse(navigationInfo) as ReaderNavigation,
         );
     }
+}
+
+/**
+ * Copy a Zotero PDF attachment into the vault and open it with Obsidian's
+ * native PDF viewer. This is intentionally opt-in: ZotFlow's own reader and
+ * annotation sync remain the default attachment workflow.
+ */
+export async function openAttachmentInNativePdfViewer(
+    libraryID: number,
+    key: string,
+    app: App,
+): Promise<void> {
+    if (services.settings.overwriteViewer) {
+        new Notice(
+            "Disable ZotFlow's PDF/EPUB/HTML Viewer override before opening attachments in Obsidian's native PDF viewer.",
+            8000,
+        );
+        return;
+    }
+
+    const attachment = await workerBridge.dbHelper.getItem(libraryID, key);
+    if (!attachment || attachment.itemType !== "attachment") {
+        throw new Error("Attachment metadata could not be found.");
+    }
+
+    const filename = attachment.raw.data.filename;
+    if (
+        !filename ||
+        filename === "." ||
+        filename === ".." ||
+        filename.includes("/") ||
+        filename.includes("\\")
+    ) {
+        throw new Error("Attachment has no valid filename.");
+    }
+
+    const vaultPath = normalizePath(
+        `Zotero Attachments/${libraryID}/${key}/${filename}`,
+    );
+    let file = app.vault.getAbstractFileByPath(vaultPath);
+    if (!(file instanceof TFile)) {
+        new Notice("Copying attachment into the vault…");
+        const { blob } = await workerBridge.downloadAttachment(
+            attachment as IDBZoteroItem<AttachmentData>,
+        );
+        file = await saveBinaryFile(app, vaultPath, await blob.arrayBuffer());
+    }
+
+    if (!(file instanceof TFile)) {
+        throw new Error("Attachment could not be copied into the vault.");
+    }
+
+    const leaf = app.workspace.getLeaf("tab");
+    await leaf.openFile(file);
+    void app.workspace.revealLeaf(leaf);
 }
 
 /**

--- a/src/worker/services/attachment.ts
+++ b/src/worker/services/attachment.ts
@@ -90,15 +90,10 @@ export class AttachmentService {
             (linkMode === "imported_file" || linkMode === "imported_url") &&
             (await this.parentHost.isDesktopApp())
         ) {
-            const storagePath = this.settings.zoteroStoragePath.trim();
-            if (!storagePath) {
-                throw new ZotFlowError(
-                    ZotFlowErrorCode.CONFIG_MISSING,
-                    "AttachmentService",
-                    "Zotero storage path is not configured",
-                );
-            }
-            return this.resolveLocalStorageFilePath(item, storagePath);
+            return this.resolveExistingLocalStorageFilePath(
+                item,
+                this.getZoteroStoragePaths(),
+            );
         }
 
         return null;
@@ -1001,24 +996,13 @@ export class AttachmentService {
     private async readFromLocalStorage(
         item: IDBZoteroItem<AttachmentData>,
     ): Promise<Blob> {
-        const storagePath = this.settings.zoteroStoragePath.trim();
-        if (!storagePath) {
-            const message =
-                "Zotero storage path is not configured. Configure Zotero Storage Path in ZotFlow settings.";
-            this.parentHost.notify("error", message);
-            throw new ZotFlowError(
-                ZotFlowErrorCode.CONFIG_MISSING,
-                "AttachmentService",
-                message,
-            );
-        }
-
+        const storagePaths = this.getZoteroStoragePaths();
         const itemKey = this.requireStoragePathSegment(item.key, "item key");
         let filePath: string | undefined;
         try {
-            filePath = await this.resolveLocalStorageFilePath(
+            filePath = await this.resolveExistingLocalStorageFilePath(
                 item,
-                storagePath,
+                storagePaths,
             );
             this.parentHost.log(
                 "info",
@@ -1050,9 +1034,68 @@ export class AttachmentService {
                 ZotFlowErrorCode.RESOURCE_MISSING,
                 "AttachmentService",
                 message,
-                { itemKey, filePath, storagePath },
+                { itemKey, filePath, storagePaths },
             );
         }
+    }
+
+    /**
+     * Parse the existing storage setting as an ordered list. A single path is
+     * still accepted unchanged; additional paths may be separated by semicolons
+     * or line breaks.
+     */
+    private getZoteroStoragePaths(): string[] {
+        const storagePaths = this.settings.zoteroStoragePath
+            .split(/[;\r\n]+/)
+            .map((path) => path.trim())
+            .filter((path) => path.length > 0);
+
+        if (storagePaths.length === 0) {
+            throw new ZotFlowError(
+                ZotFlowErrorCode.CONFIG_MISSING,
+                "AttachmentService",
+                "Zotero storage path is not configured. Configure Zotero Storage Path in ZotFlow settings.",
+            );
+        }
+
+        return [...new Set(storagePaths)];
+    }
+
+    /** Resolve the first configured Zotero storage path that contains the attachment. */
+    private async resolveExistingLocalStorageFilePath(
+        item: IDBZoteroItem<AttachmentData>,
+        storagePaths: string[],
+    ): Promise<string> {
+        const attemptedPaths: string[] = [];
+        let lastError: unknown;
+
+        for (const storagePath of storagePaths) {
+            const filePath = await this.resolveLocalStorageFilePath(
+                item,
+                storagePath,
+            );
+            attemptedPaths.push(filePath);
+
+            try {
+                await this.parentHost.statExternalFile(filePath);
+                return filePath;
+            } catch (error) {
+                lastError = error;
+                this.parentHost.log(
+                    "debug",
+                    "Attachment was not found in configured Zotero storage directory.",
+                    "AttachmentService",
+                    { filePath, error },
+                );
+            }
+        }
+
+        throw new ZotFlowError(
+            ZotFlowErrorCode.RESOURCE_MISSING,
+            "AttachmentService",
+            "Attachment was not found in any configured Zotero storage directory.",
+            { storagePaths, attemptedPaths, cause: lastError },
+        );
     }
 
     private async resolveLocalStorageFilePath(


### PR DESCRIPTION
## Summary

- Support multiple local Zotero storage directories, checked in order.
- Add an opt-in context-menu action to copy a PDF attachment into the vault and open it in Obsidian's native PDF viewer.

## Details

- Existing single-directory configurations remain supported.
- Multiple storage paths may be separated by semicolons or line breaks.
- The native viewer action is available for PDF attachments and requires ZotFlow's PDF/EPUB/HTML viewer override to be disabled.
- The copied file is reused from `Zotero Attachments/<libraryID>/<attachmentKey>/<filename>`.

## Verification

- `npm run build:plugin`
- Tested with attachments stored in two separate Zotero storage roots and opened in Obsidian's native PDF viewer.